### PR TITLE
Hotfix Add second reference to severity diagnosis function

### DIFF
--- a/src/modules/Results/Results.tsx
+++ b/src/modules/Results/Results.tsx
@@ -50,6 +50,8 @@ const Results = ({ formValues }: ResultsProps) => {
     }
   };
 
+  const severity = diagnoseSeverity();
+
   const handleClose = () => {
     navigate('/welcome');
   };
@@ -108,7 +110,7 @@ const Results = ({ formValues }: ResultsProps) => {
                 {animatedTotal}
                 <span className="score-maximum-text">/54</span>
               </p>
-              <p className="score-sub-text">No Symptoms</p>
+              <p className="score-sub-text">{severity}</p>
             </Container>
           </>
         </div>
@@ -122,7 +124,7 @@ const Results = ({ formValues }: ResultsProps) => {
             {diagnoseSeverity() !== 'Invalid score' && (
               <>
                 This score indicates that you have <br />
-                {diagnoseSeverity()} symptoms
+                {severity} symptoms
               </>
             )}
           </p>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Text in the bottom portion of the results screen was dynamic according to the diagnosis function, but the text directly underneath score was not. Fixed this

​
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master`/`main` for bug fixes and documentation updates, `develop` for new features and backwards).
- [x] My code follows the code style of this project and I have formatted my code.
- [x] I have reviewed my code before submitting this pull request
- [x] I've added my changes to any documentation and code comments are clear and understandable for anyone

## Screenshots/gifs of changes (if applicable)
